### PR TITLE
Windows環境で文字エンコードによる不具合を解消

### DIFF
--- a/build_json.py
+++ b/build_json.py
@@ -7,7 +7,7 @@ patiants_list = []
 patiants_summary_dic = {}
 main_summary_dic = {}
 
-with open('data/patients.csv') as csvfile:
+with open('data/patients.csv', 'r', encoding="utf-8") as csvfile:
     reader = csv.DictReader(csvfile)
     for row in reader:
         patiants_list.append(row)
@@ -36,7 +36,7 @@ for date in datelist:
 
 main_summary_dic = {}
 
-with open('data/main_summary.csv') as csvfile:
+with open('data/main_summary.csv', 'r', encoding="utf-8") as csvfile:
     reader = csv.reader(csvfile)
     for row in reader:
         main_summary_dic[row[0]] = int(row[1])

--- a/pretty_json.py
+++ b/pretty_json.py
@@ -1,4 +1,5 @@
-import sys, json
+import io, sys, json
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
 print(json.dumps(json.loads(sys.stdin.read()), indent=4, ensure_ascii=False))
 


### PR DESCRIPTION
- csvの読込み時の文字エンコードにUTF-8を指定
- 標準出力の文字エンコードをUTF-8に変更